### PR TITLE
[G.EXP.23-CPP] Fix warning_1821

### DIFF
--- a/libqpdf/QPDFFormFieldObjectHelper.cc
+++ b/libqpdf/QPDFFormFieldObjectHelper.cc
@@ -253,11 +253,11 @@ QPDFFormFieldObjectHelper::isChecked()
     return isCheckbox() && getValue().isName() && (getValue().getName() != "/Off");
 }
 
-bool
-QPDFFormFieldObjectHelper::isRadioButton()
+bool QPDFFormFieldObjectHelper::isRadioButton()
 {
-    return ((getFieldType() == "/Btn") && ((getFlags() & ff_btn_radio) == ff_btn_radio));
+    return ((getFieldType() == "/Btn") && (static_cast<unsigned int>(getFlags()) & static_cast<unsigned int>(ff_btn_radio)) == static_cast<unsigned int>(ff_btn_radio));
 }
+
 
 bool
 QPDFFormFieldObjectHelper::isPushbutton()


### PR DESCRIPTION
[G.EXP.23-CPP] The type of "this->getFlags()" is int. 
The operand "this->getFlags()" with signed type cannot be involved in the bit operation  of "this->getFlags() & ff_btn_radio"