### PR TITLE
[G.EXP.23-CPP] Fix warning_1811

### DIFF
--- a/libqpdf/QPDFFormFieldObjectHelper.cc
+++ b/libqpdf/QPDFFormFieldObjectHelper.cc
@@ -241,11 +241,14 @@ QPDFFormFieldObjectHelper::isText()
     return (getFieldType() == "/Tx");
 }
 
-bool
-QPDFFormFieldObjectHelper::isCheckbox()
+bool QPDFFormFieldObjectHelper::isCheckbox()
 {
-    return ((getFieldType() == "/Btn") && ((getFlags() & (ff_btn_radio | ff_btn_pushbutton)) == 0));
+    return ((getFieldType() == "/Btn") &&
+            (static_cast<unsigned int>(getFlags()) &
+             (static_cast<unsigned int>(ff_btn_radio) |
+              static_cast<unsigned int>(ff_btn_pushbutton))) == 0);
 }
+
 
 bool
 QPDFFormFieldObjectHelper::isChecked()


### PR DESCRIPTION
[G.EXP.23-CPP] The type of "this->getFlags()" is int. 
The operand "this->getFlags()" with signed type cannot be involved in the bit operation  of "this->getFlags() & (ff_btn_radio | ff_btn_pushbutton)"